### PR TITLE
Moved UID field to profile

### DIFF
--- a/lib/omniauth-dsds/lib/user.rb
+++ b/lib/omniauth-dsds/lib/user.rb
@@ -5,7 +5,7 @@ module Omniauth
 
       def self.build_from(auth_hash)
         new(
-          uid:   auth_hash.fetch("user").fetch("uid"),
+          uid:   auth_hash.fetch("profile").fetch("uid"),
           name:  auth_hash.fetch("profile").fetch("name"),
           email: auth_hash.fetch("profile").fetch("email"),
           roles: auth_hash.fetch("roles")

--- a/lib/omniauth-dsds/spec/sign_in_helper.rb
+++ b/lib/omniauth-dsds/spec/sign_in_helper.rb
@@ -8,7 +8,7 @@ module Omniauth
 
           OmniAuth.config.mock_auth[:defence_request] = OmniAuth::AuthHash.new({
             provider: "defence_request",
-            uid: "123456789",
+            uid: "12345678-abcd-1234-abcd-1234567890",
             credentials: {
               token: token,
             }
@@ -19,9 +19,7 @@ module Omniauth
 
           response_body = profile.reverse_merge({
             "user" => {
-                "id" => 1,
                 "email" => "bob.smith@world.com",
-                "uid" => "12345678-abcd-1234-abcd-1234567890"
             },
             "profile" => {
                 "name" => "Bob Smith",
@@ -35,7 +33,8 @@ module Omniauth
                     "postcode" => ""
                 },
                 "PIN" => "1234",
-                "organisation_ids" => [1,2]
+                "organisation_ids" => [1,2],
+                "uid" => "12345678-abcd-1234-abcd-1234567890"
             },
             "roles" => [
                 "admin", "foo", "bar"

--- a/lib/omniauth/strategies/defence_request.rb
+++ b/lib/omniauth/strategies/defence_request.rb
@@ -10,7 +10,7 @@ module OmniAuth
         redirect_url: ENV.fetch('AUTHENTICATION_REDIRECT_URI')
       }
 
-      uid { raw_info["user"]["uid"] }
+      uid { raw_info["profile"]["uid"] }
 
       def raw_info
         @_raw_info ||= MultiJson.decode access_token.get("/api/v1/me").body

--- a/spec/omniauth-dsds/lib/user_spec.rb
+++ b/spec/omniauth-dsds/lib/user_spec.rb
@@ -6,9 +6,7 @@ RSpec.describe Omniauth::Dsds::User, ".build_from" do
   it "builds a user from the auth hash" do
     auth_hash = {
       "user" => {
-          "id"    => 1,
           "email" => "bob.smith@world.com",
-          "uid"   => "12345678-abcd-1234-abcd-1234567890"
       },
       "profile" => {
           "name"      => "Bob Smith",
@@ -22,7 +20,8 @@ RSpec.describe Omniauth::Dsds::User, ".build_from" do
               "postcode" => ""
           },
           "PIN"              => "1234",
-          "organisation_ids" => [1,2]
+          "organisation_ids" => [1,2],
+          "uid"   => "12345678-abcd-1234-abcd-1234567890"
       },
       "roles" => [
           "admin", "foo", "bar"


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/92326100

* The `/me` endpoint now expects the UID to be under `profile` not `user`