### PR TITLE
Restrict logins to consuming applications by role

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ object representing the currently logged in user.
 It also provides a Devise-like `authenticate_user!` method, which redirects
 to the login workflow for the Authentication application.
 
+If the User does not have any roles for the application (as returned by the profile API response) then the session will be cleared and the User redirected to the login page.
+
+Override the authentication_application_id and authentication_application_secret methods to customize where OAuth credentials are loaded from.
+
 ## Contributing
 
 1. Fork it (https://github.com/[my-github-username]/omniauth-dsds/fork)

--- a/lib/omniauth-dsds.rb
+++ b/lib/omniauth-dsds.rb
@@ -1,4 +1,5 @@
 require "omniauth-dsds/version"
 require "omniauth-dsds/lib/user"
+require "omniauth-dsds/lib/user_builder"
 require "omniauth-dsds/lib/controller_methods"
 require "omniauth/strategies/defence_request"

--- a/lib/omniauth-dsds/lib/controller_methods.rb
+++ b/lib/omniauth-dsds/lib/controller_methods.rb
@@ -26,8 +26,9 @@ module Omniauth
       def build_user
         UserBuilder.new(
           app_id:     authentication_application_id,
-          app_secret: authentication_application_secret
-        ).build_user access_token
+          app_secret: authentication_application_secret,
+          token:      access_token
+        ).build_user
       end
 
       def authentication_application_id

--- a/lib/omniauth-dsds/lib/controller_methods.rb
+++ b/lib/omniauth-dsds/lib/controller_methods.rb
@@ -20,26 +20,22 @@ module Omniauth
       end
 
       def fetch_current_user
-        return nil unless access_token
-        build_user
-
-      rescue OAuth2::Error
-        reset_session
-        nil
+        build_user || (reset_session; nil)
       end
 
       def build_user
-        User.build_from strategy_with_access_token(token: access_token).raw_info
+        UserBuilder.new(
+          app_id:     authentication_application_id,
+          app_secret: authentication_application_secret
+        ).build_user access_token
       end
 
-      def strategy
-        OmniAuth::Strategies::DefenceRequest.new ENV.fetch('AUTHENTICATION_APPLICATION_ID'), ENV.fetch('AUTHENTICATION_APPLICATION_SECRET')
+      def authentication_application_id
+        ENV.fetch('AUTHENTICATION_APPLICATION_ID')
       end
 
-      def strategy_with_access_token(token: )
-        strategy.tap do |strat|
-          strat.access_token = OAuth2::AccessToken.new strat.client, token
-        end
+      def authentication_application_secret
+        ENV.fetch('AUTHENTICATION_APPLICATION_SECRET')
       end
     end
   end

--- a/lib/omniauth-dsds/lib/user_builder.rb
+++ b/lib/omniauth-dsds/lib/user_builder.rb
@@ -2,15 +2,21 @@ module Omniauth
   module Dsds
     class UserBuilder
 
-      class NullRawInfo < Hash
+      class NullRawInfo
         def initialize
-          self["profile"] = {
-            "uid" => "",
-            "name" => "",
-            "email" => "",
-            "organisation_uids" => []
+          @data = {
+            "profile" => {
+              "uid" => "",
+              "name" => "",
+              "email" => "",
+              "organisation_uids" => []
+            },
+            "roles" => []
           }
-          self['roles'] = []
+        end
+
+        def [](key)
+          @data[key]
         end
       end
 

--- a/lib/omniauth-dsds/lib/user_builder.rb
+++ b/lib/omniauth-dsds/lib/user_builder.rb
@@ -20,12 +20,13 @@ module Omniauth
         end
       end
 
-      def initialize(app_id:, app_secret:)
-        app_id = app_id
-        app_secret = app_secret
+      def initialize(app_id:, app_secret:, token:)
+        @app_id = app_id
+        @app_secret = app_secret
+        @token = token
       end
 
-      def build_user(token)
+      def build_user
         return nil unless token
 
         raw_info = fetch_raw_info(token)
@@ -37,7 +38,7 @@ module Omniauth
 
       private
 
-      attr_reader :access_token, :app_id, :app_secret
+      attr_reader :token, :app_id, :app_secret
 
       def strategy
         OmniAuth::Strategies::DefenceRequest.new app_id, app_secret

--- a/lib/omniauth-dsds/lib/user_builder.rb
+++ b/lib/omniauth-dsds/lib/user_builder.rb
@@ -1,0 +1,55 @@
+module Omniauth
+  module Dsds
+    class UserBuilder
+
+      class NullRawInfo < Hash
+        def initialize
+          self["profile"] = {
+            "uid" => "",
+            "name" => "",
+            "email" => "",
+            "organisation_uids" => []
+          }
+          self['roles'] = []
+        end
+      end
+
+      def initialize(app_id:, app_secret:)
+        app_id = app_id
+        app_secret = app_secret
+      end
+
+      def build_user(token)
+        return nil unless token
+
+        raw_info = fetch_raw_info(token)
+
+        unless raw_info['roles'].nil? || raw_info['roles'].empty?
+          User.build_from raw_info
+        end
+      end
+
+      private
+
+      attr_reader :access_token, :app_id, :app_secret
+
+      def strategy
+        OmniAuth::Strategies::DefenceRequest.new app_id, app_secret
+      end
+
+      def strategy_with_access_token(token: )
+        strategy.tap do |strat|
+          strat.access_token = OAuth2::AccessToken.new strat.client, token
+        end
+      end
+
+      def fetch_raw_info(token)
+
+        strategy_with_access_token(token: token).raw_info
+
+        rescue OAuth2::Error
+          NullRawInfo.new
+      end
+    end
+  end
+end

--- a/lib/omniauth/strategies/defence_request.rb
+++ b/lib/omniauth/strategies/defence_request.rb
@@ -2,12 +2,28 @@ require "omniauth-oauth2"
 
 module OmniAuth
   module Strategies
+
+    module CallbackOverride
+      def callback_phase
+        if raw_info['roles'].nil? || raw_info['roles'].empty?
+          fail!(:unauthorized, OAuth2::CallbackError.new(:unauthorized, 'Unauthorized access'))
+        else
+          super
+        end
+      end
+    end
+
+    # Need to check roles after the access_token has been built by OmniAuth::OAuth2#callback_phase 
+    # but before the parent app is called by OmniAuth::Strategy#callback_phase
+    # so we place a module in the ancestors chain between them
+    OAuth2.send :include, CallbackOverride
+
     class DefenceRequest < OmniAuth::Strategies::OAuth2
       option :name, "defence_request"
 
       option :client_options, {
-        site: ENV.fetch('AUTHENTICATION_SITE_URL'),
-        redirect_url: ENV.fetch('AUTHENTICATION_REDIRECT_URI')
+        site: ENV.fetch('AUTHENTICATION_SITE_URL', nil),
+        redirect_url: ENV.fetch('AUTHENTICATION_REDIRECT_URI', nil)
       }
 
       uid { raw_info["profile"]["uid"] }

--- a/lib/omniauth/strategies/defence_request.rb
+++ b/lib/omniauth/strategies/defence_request.rb
@@ -2,22 +2,6 @@ require "omniauth-oauth2"
 
 module OmniAuth
   module Strategies
-
-    module CallbackOverride
-      def callback_phase
-        if raw_info['roles'].nil? || raw_info['roles'].empty?
-          fail!(:unauthorized, OAuth2::CallbackError.new(:unauthorized, 'Unauthorized access'))
-        else
-          super
-        end
-      end
-    end
-
-    # Need to check roles after the access_token has been built by OmniAuth::OAuth2#callback_phase 
-    # but before the parent app is called by OmniAuth::Strategy#callback_phase
-    # so we place a module in the ancestors chain between them
-    OAuth2.send :include, CallbackOverride
-
     class DefenceRequest < OmniAuth::Strategies::OAuth2
       option :name, "defence_request"
 

--- a/spec/omniauth-dsds/lib/controller_methods_spec.rb
+++ b/spec/omniauth-dsds/lib/controller_methods_spec.rb
@@ -77,6 +77,7 @@ RSpec.describe Omniauth::Dsds::ControllerMethods do
           hash_including(
             app_id: ENV['AUTHENTICATION_APPLICATION_ID'],
             app_secret: ENV['AUTHENTICATION_APPLICATION_SECRET'],
+            token: access_token
           )
         ).and_return user_builder
 
@@ -85,7 +86,7 @@ RSpec.describe Omniauth::Dsds::ControllerMethods do
 
       it "uses the UserBuilder instance and access_token to load the user profile" do
         expect(Omniauth::Dsds::UserBuilder).to receive(:new).and_return user_builder
-        expect(user_builder).to receive(:build_user).with(access_token).and_return fake_user
+        expect(user_builder).to receive(:build_user).and_return fake_user
 
         expect(subject.current_user).to eq fake_user
       end

--- a/spec/omniauth-dsds/lib/controller_methods_spec.rb
+++ b/spec/omniauth-dsds/lib/controller_methods_spec.rb
@@ -1,11 +1,14 @@
 require "spec_helper"
 require "oauth2"
+require_relative "../../../lib/omniauth-dsds/lib/user_builder"
 require_relative "../../../lib/omniauth-dsds/lib/controller_methods"
+
 
 ENV['AUTHENTICATION_APPLICATION_ID'] = '12345'
 ENV['AUTHENTICATION_APPLICATION_SECRET'] = 'abcfe'
 
-RSpec.describe Omniauth::Dsds::ControllerMethods, "#current_user" do
+RSpec.describe Omniauth::Dsds::ControllerMethods do
+
   class FakeController
     def self.helper_method(included_method)
       @included_method = included_method
@@ -24,46 +27,82 @@ RSpec.describe Omniauth::Dsds::ControllerMethods, "#current_user" do
 
   subject { FakeController.new }
 
-  context "when the module is included" do
-    it "adds the :current_user helper method" do
-      expect(FakeController).to receive(:helper_method).with(:current_user)
+  describe "#authenticate_user!" do
+    context "with current_user" do
+      it "does not redirect" do
+        allow(subject).to receive(:current_user).and_return double("User")
+        expect(subject).not_to receive(:redirect_to)
 
-      FakeController.send(:include, Omniauth::Dsds::ControllerMethods)
+        subject.send :authenticate_user!
+      end
+    end
+
+    context "with no current_user" do
+      it "redirects to login" do
+        expect(subject).to receive(:current_user).and_return nil
+        expect(subject).to receive(:redirect_to).with("/auth/defence_request")
+
+        subject.send :authenticate_user!
+      end
     end
   end
 
-  context "with no auth token in the session" do
-    it "returns nil" do
-      expect(subject.current_user).to be_nil
-    end
-  end
+  describe "#current_user" do
+    context "when the module is included" do
+      it "adds the :current_user helper method" do
+        expect(FakeController).to receive(:helper_method).with(:current_user)
 
-  context "with an auth token in the session" do
-    before do
-      subject.session[:user_token] = "ABCDE"
-    end
-
-    let(:fake_user) { double("User") }
-
-    it "uses the strategy to load the user profile" do
-      expect(subject).to receive(:build_user).and_return fake_user
-      expect(subject.current_user).to eq fake_user
-    end
-
-    context "when the user profile does not load" do
-      before do
-        # OAuth2::Error needs a Response object to be initialized ...
-        fake_response = double("OAuth2::Response", :error= => nil, :parsed => nil, :body => '')
-        expect(subject).to receive(:build_user).and_raise OAuth2::Error.new(fake_response)
+        FakeController.send(:include, Omniauth::Dsds::ControllerMethods)
       end
+    end
 
-      it "clears the session" do
-        subject.current_user
-        expect(subject.session).to be_empty
-      end
-
+    context "with no auth token in the session" do
       it "returns nil" do
         expect(subject.current_user).to be_nil
+      end
+    end
+
+    context "with an auth token in the session" do
+      before do
+        subject.session[:user_token] = access_token
+        allow(user_builder).to receive(:build_user)
+      end
+
+      let(:access_token) { "ABCDE" }
+      let(:fake_user) { double("User") }
+      let(:user_builder) { double("UserBuilder") }
+
+      it "initializes UserBuilder with the correct args" do
+        expect(Omniauth::Dsds::UserBuilder).to receive(:new).with(
+          hash_including(
+            app_id: ENV['AUTHENTICATION_APPLICATION_ID'],
+            app_secret: ENV['AUTHENTICATION_APPLICATION_SECRET'],
+          )
+        ).and_return user_builder
+
+        subject.current_user
+      end
+
+      it "uses the UserBuilder instance and access_token to load the user profile" do
+        expect(Omniauth::Dsds::UserBuilder).to receive(:new).and_return user_builder
+        expect(user_builder).to receive(:build_user).with(access_token).and_return fake_user
+
+        expect(subject.current_user).to eq fake_user
+      end
+
+      context "when the user profile does not load" do
+        before do
+          expect(subject).to receive(:build_user).and_return nil
+        end
+
+        it "clears the session" do
+          subject.current_user
+          expect(subject.session).to be_empty
+        end
+
+        it "returns nil" do
+          expect(subject.current_user).to be_nil
+        end
       end
     end
   end

--- a/spec/omniauth-dsds/lib/user_builder_spec.rb
+++ b/spec/omniauth-dsds/lib/user_builder_spec.rb
@@ -1,0 +1,45 @@
+require "spec_helper"
+require_relative "../../../lib/omniauth-dsds/lib/user"
+require_relative "../../../lib/omniauth-dsds/lib/user_builder"
+require "omniauth"
+
+RSpec.describe Omniauth::Dsds::UserBuilder do
+  subject { Omniauth::Dsds::UserBuilder.new app_id: app_id, app_secret: app_secret }
+  let(:app_id) { "12345" }
+  let(:app_secret) { "ABCDE" }
+  let(:token) { "ZXCVB" }
+
+  describe "#build_user" do
+    context "with a blank token" do
+      let(:token) { nil }
+
+      it "returns nil" do
+        expect(subject.build_user(token)).to be_nil
+      end
+    end
+
+    before do
+      allow(subject).to receive(:fetch_raw_info).with(token).and_return raw_info_response
+    end
+
+    let(:roles) { ['cso'] }
+    let(:raw_info_response) { { "roles" => roles } }
+
+    context "when raw_info has no roles" do
+      let(:roles) { [] }
+
+      it "returns nil" do
+        expect(subject.build_user(token)).to be_nil
+      end
+    end
+
+    context "when raw_info has roles" do
+      it "returns a new User object" do
+        stub_user = double("User")
+        expect(Omniauth::Dsds::User).to receive(:build_from).with(raw_info_response).and_return stub_user
+
+        expect(subject.build_user(token)).to eq stub_user
+      end
+    end
+  end
+end

--- a/spec/omniauth-dsds/lib/user_builder_spec.rb
+++ b/spec/omniauth-dsds/lib/user_builder_spec.rb
@@ -3,43 +3,45 @@ require_relative "../../../lib/omniauth-dsds/lib/user"
 require_relative "../../../lib/omniauth-dsds/lib/user_builder"
 require "omniauth"
 
-RSpec.describe Omniauth::Dsds::UserBuilder do
-  subject { Omniauth::Dsds::UserBuilder.new app_id: app_id, app_secret: app_secret }
+RSpec.describe Omniauth::Dsds::UserBuilder, "#build_user" do
+  subject {
+    Omniauth::Dsds::UserBuilder.new(
+      app_id: app_id, app_secret: app_secret, token: token
+    )
+  }
   let(:app_id) { "12345" }
   let(:app_secret) { "ABCDE" }
   let(:token) { "ZXCVB" }
 
-  describe "#build_user" do
-    context "with a blank token" do
-      let(:token) { nil }
+  context "with a blank token" do
+    let(:token) { nil }
 
-      it "returns nil" do
-        expect(subject.build_user(token)).to be_nil
-      end
+    it "returns nil" do
+      expect(subject.build_user).to be_nil
     end
+  end
 
-    before do
-      allow(subject).to receive(:fetch_raw_info).with(token).and_return raw_info_response
+  before do
+    allow(subject).to receive(:fetch_raw_info).with(token).and_return raw_info_response
+  end
+
+  let(:roles) { ['cso'] }
+  let(:raw_info_response) { { "roles" => roles } }
+
+  context "when raw_info has no roles" do
+    let(:roles) { [] }
+
+    it "returns nil" do
+      expect(subject.build_user).to be_nil
     end
+  end
 
-    let(:roles) { ['cso'] }
-    let(:raw_info_response) { { "roles" => roles } }
+  context "when raw_info has roles" do
+    it "returns a new User object" do
+      stub_user = double("User")
+      expect(Omniauth::Dsds::User).to receive(:build_from).with(raw_info_response).and_return stub_user
 
-    context "when raw_info has no roles" do
-      let(:roles) { [] }
-
-      it "returns nil" do
-        expect(subject.build_user(token)).to be_nil
-      end
-    end
-
-    context "when raw_info has roles" do
-      it "returns a new User object" do
-        stub_user = double("User")
-        expect(Omniauth::Dsds::User).to receive(:build_from).with(raw_info_response).and_return stub_user
-
-        expect(subject.build_user(token)).to eq stub_user
-      end
+      expect(subject.build_user).to eq stub_user
     end
   end
 end


### PR DESCRIPTION
* Only return a User from #current_user if the user has a role in the application (taken from the profile response)
* Extract the building of the current_user object away from controller mixin module 
* Expose authentication_application_id and authentication_application_secret methods to allow application to customize where OAuth credentials come from