### PR TITLE
Updated DefenceRequestStrategy with changes to auth app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Omniauth::Dsds
 
-This gem contains the DSDS strategy for OmniAuth.
+This gem contains the OmniAuth strategy to authenticate against the [DRS Authentication provider](https://github.com/ministryofjustice/defence-request-service-auth).
 
 ## Installation
 
@@ -33,8 +33,11 @@ from the authentication service provider.
 You will need to set environment variables in order for the gem
 to know where the authentication service resides, and where Omniauth
 needs to redirect back to after authenticating. These should be set as
-`ENV[AUTHENTICATION_SITE_URL]` and `ENV[AUTHENTICATION_REDIRECT_URI]`
+`ENV['AUTHENTICATION_SITE_URL']` and `ENV['AUTHENTICATION_REDIRECT_URI']`
 respectively.
+
+The user details endpoint on the authentication provider will default to
+`/api/v1/me` but can be overridden by setting `ENV['AUTHENTICATION_RAW_INFO_PATH']`
 
 ### Controller mix-ins
 
@@ -52,6 +55,13 @@ to the login workflow for the Authentication application.
 If the User does not have any roles for the application (as returned by the profile API response) then the session will be cleared and the User redirected to the login page.
 
 Override the authentication_application_id and authentication_application_secret methods to customize where OAuth credentials are loaded from.
+
+### Authorization
+If the current_user does not have permission to access the application then the Authentication provider will redirect to `auth/failure?message=unauthorized` rather than the success route. See [https://github.com/intridea/omniauth/wiki](https://github.com/intridea/omniauth/wiki)
+
+### Debugging
+It can be handy to see exactly what requests are being made to the authentication provider.
+Set `ENV['OAUTH_DEBUG']` to enable debug logging.
 
 ## Contributing
 

--- a/lib/omniauth-dsds/lib/user.rb
+++ b/lib/omniauth-dsds/lib/user.rb
@@ -4,13 +4,13 @@ module Omniauth
       attr_reader :uid, :email, :name, :roles, :organisation_uids
 
       def self.build_from(auth_hash)
-        profile = auth_hash.fetch("profile")
+        user = auth_hash.fetch("user")
         new(
-          uid:   profile.fetch("uid"),
-          name:  profile.fetch("name"),
-          email: profile.fetch("email"),
+          uid:   user.fetch("uid"),
+          name:  user.fetch("name"),
+          email: user.fetch("email"),
           roles: Array(auth_hash.fetch("roles")),
-          organisation_uids: Array(profile.fetch("organisation_uids"))
+          organisation_uids: Array(user.fetch("organisation_uids"))
         )
       end
 

--- a/lib/omniauth-dsds/lib/user_builder.rb
+++ b/lib/omniauth-dsds/lib/user_builder.rb
@@ -5,7 +5,7 @@ module Omniauth
       class NullRawInfo
         def initialize
           @data = {
-            "profile" => {
+            "user" => {
               "uid" => "",
               "name" => "",
               "email" => "",

--- a/spec/omniauth-dsds/lib/user_spec.rb
+++ b/spec/omniauth-dsds/lib/user_spec.rb
@@ -6,9 +6,6 @@ RSpec.describe Omniauth::Dsds::User, ".build_from" do
   it "builds a user from the auth hash" do
     auth_hash = {
       "user" => {
-          "email" => "bob.smith@world.com",
-      },
-      "profile" => {
           "name"      => "Bob Smith",
           "email"     => "bob.smith@world.com",
           "telephone" => "0123456789",

--- a/spec/omniauth/strategies/defence_request_spec.rb
+++ b/spec/omniauth/strategies/defence_request_spec.rb
@@ -1,35 +1,74 @@
-ENV['AUTHENTICATION_SITE_URL'] = 'https://example.com/site_url'
+ENV['AUTHENTICATION_SITE_URL'] = 'https://example.com'
 ENV['AUTHENTICATION_REDIRECT_URI'] = 'https://example.com/redirect_url'
+ENV['AUTHENTICATION_RAW_INFO_PATH'] = "/api/v42/foobars"
 
 require 'spec_helper'
 require 'omniauth-dsds'
 
 describe "defence_request strategy" do
-  let(:request) { double('Request', :params => {}, :cookies => {}, :env => {}) }
-
-  before :each do
+  subject do
+    args = ['appid', 'secret', @options || {}].compact
+    OmniAuth::Strategies::DefenceRequest.new(*args).tap do |strategy|
+      allow(strategy).to receive(:request) {
+        request
+      }
+    end
   end
 
-  describe 'client options' do
-    subject do
-      args = ['appid', 'secret', @options || {}].compact
-      OmniAuth::Strategies::DefenceRequest.new(*args).tap do |strategy|
-        allow(strategy).to receive(:request) {
-          request
-        }
-      end
-    end
+  let(:request) { double('Request', :params => {}, :cookies => {}, :env => {}) }
 
+  describe 'client options' do
     it 'should have correct name' do
       expect(subject.options.name).to eq('defence_request')
     end
 
     it 'should have correct site pulled from the environment' do
-      expect(subject.options.client_options.site).to eq('https://example.com/site_url')
+      expect(subject.options.client_options.site).to eq('https://example.com')
     end
 
     it 'should have correct redirect url pulled from the environment' do
       expect(subject.options.client_options.redirect_url).to eq('https://example.com/redirect_url')
+    end
+
+    it 'should have correct raw_info_path pulled from the environment' do
+      expect(subject.options.client_options.raw_info_path).to eq("/api/v42/foobars")
+    end
+  end
+
+  describe "raw_info" do
+    before do
+      allow(fake_access_token).to receive(:get).and_return fake_response
+      allow(fake_access_token).to receive(:token).and_return token
+      allow(subject).to receive(:access_token).and_return fake_access_token
+    end
+
+    let(:token) { "sdljhfslfj" }
+    let(:fake_access_token) { double("AccessToken") }
+    let(:fake_response) { double("Response", body: "{\"fake\": \"response\"}") }
+
+    it "uses the access_token to make a request to the user details url on the auth server" do
+      expect(fake_access_token).to receive(:get).with(subject.options.client_options.raw_info_path).and_return fake_response
+      subject.raw_info
+    end
+
+    it "returns the response parsed as json" do
+      expect(subject.raw_info).to eq({"fake" => "response"})
+    end
+
+    context "when the ENV[\"OAUTH_DEBUG\"] flag is set" do
+      it "prints the user details request as a curl command" do
+        allow(ENV).to receive(:[]).with("OAUTH_DEBUG").and_return "true"
+        expect(subject).to receive(:log).with(:debug, "curl -H \"Accept: application/json\" -H \"Authorization: Bearer #{token}\" https://example.com/api/v42/foobars")
+        subject.raw_info
+      end
+    end
+
+    context "when the ENV[\"OAUTH_DEBUG\"] flag is not set" do
+      it "does not print user details request" do
+        allow(ENV).to receive(:[]).with("OAUTH_DEBUG").and_return nil
+        expect(subject).not_to receive(:log)
+        subject.raw_info
+      end
     end
   end
 end


### PR DESCRIPTION
* raw_info response now expects a User object, not a Profile object
* raw_info path is not configurable
* setting ENV['OAUTH_DEBUG'] will print out curl command for raw_info API request