### PR TITLE
Use AUTH_DEBUG

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ If the current_user does not have permission to access the application then the 
 
 ### Debugging
 It can be handy to see exactly what requests are being made to the authentication provider.
-Set `ENV['OAUTH_DEBUG']` to enable debug logging.
+Set `ENV['AUTH_DEBUG']` to enable debug logging.
 
 ## Contributing
 

--- a/lib/omniauth/strategies/defence_request.rb
+++ b/lib/omniauth/strategies/defence_request.rb
@@ -29,8 +29,9 @@ module OmniAuth
       uid { raw_info["user"]["uid"] }
 
       def raw_info
-        log_request
         @_raw_info ||= MultiJson.decode access_token.get(raw_info_path).body
+        log_request
+        @_raw_info
       end
 
       private
@@ -44,9 +45,12 @@ module OmniAuth
       end
 
       def log_request
-        return unless ENV["OAUTH_DEBUG"]
+        return unless ENV["AUTH_DEBUG"]
 
-        log :debug, "curl -H \"Accept: application/json\" -H \"Authorization: Bearer #{access_token.token}\" #{full_raw_info_url}"
+        require 'pp'
+        puts "\n#{full_raw_info_url} result:"
+        pp @_raw_info
+        puts "curl -H \"Accept: application/json\" -H \"Authorization: Bearer #{access_token.token}\" #{full_raw_info_url}\n\n"
       end
     end
   end

--- a/spec/omniauth/strategies/defence_request_spec.rb
+++ b/spec/omniauth/strategies/defence_request_spec.rb
@@ -57,15 +57,17 @@ describe "defence_request strategy" do
 
     context "when the ENV[\"OAUTH_DEBUG\"] flag is set" do
       it "prints the user details request as a curl command" do
-        allow(ENV).to receive(:[]).with("OAUTH_DEBUG").and_return "true"
-        expect(subject).to receive(:log).with(:debug, "curl -H \"Accept: application/json\" -H \"Authorization: Bearer #{token}\" https://example.com/api/v42/foobars")
+        allow(ENV).to receive(:[]).with("AUTH_DEBUG").and_return "true"
+        expect(subject).to receive(:puts).with("\nhttps://example.com/api/v42/foobars result:")
+        expect(subject).to receive(:pp).with({"fake" => "response"})
+        expect(subject).to receive(:puts).with("curl -H \"Accept: application/json\" -H \"Authorization: Bearer #{token}\" https://example.com/api/v42/foobars\n\n")
         subject.raw_info
       end
     end
 
     context "when the ENV[\"OAUTH_DEBUG\"] flag is not set" do
       it "does not print user details request" do
-        allow(ENV).to receive(:[]).with("OAUTH_DEBUG").and_return nil
+        allow(ENV).to receive(:[]).with("AUTH_DEBUG").and_return nil
         expect(subject).not_to receive(:log)
         subject.raw_info
       end


### PR DESCRIPTION
use AUTH_DEBUG ENV variable as OAUTH_DEBUG exposes runtime error in omniauth gem

This avoids the this bug https://github.com/intridea/oauth2/issues/189 but will still log to console the extra debug info